### PR TITLE
fix: move root hints to a folder unbound can access, add OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,14 @@ LABEL \
 	org.label-schema.vcs-url="https://github.com/githubcdr/docker-unbound" \
 	org.label-schema.schema-version="1.0"
 
-RUN apk add --update --no-cache unbound curl ca-certificates s6 \
-            && curl -o /etc/unbound/root.hints https://www.internic.net/domain/named.cache
+
+RUN apk add --update --no-cache unbound curl openssl ca-certificates s6 
+
+RUN mkdir -p /var/lib/unbound \
+ && curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache \
+ && chmod 755 /var/lib/unbound \
+ && chmod 644 /var/lib/unbound/root.hints \
+ && chown -R unbound:unbound /var/lib/unbound
 
 # add files, this also creates the layout for the filesystem
 COPY files/root/ /

--- a/files/root/etc/unbound/unbound.conf
+++ b/files/root/etc/unbound/unbound.conf
@@ -24,7 +24,7 @@ server:
         pidfile: "/var/run/unbound.pid"
         port: 53
         prefetch: yes
-        root-hints: /etc/unbound/root.hints
+        root-hints: /var/lib/unbound/root.hints
         rrset-roundrobin: yes
         so-reuseport: yes
         statistics-cumulative: yes


### PR DESCRIPTION
@githubcdr Apologies... I didn't fully test that previous fix. 

While it did remove the startup error, I didn't notice that the latest version of unbound had some changes that needed resolving as well, and the service wasn't correctly starting without those changes.

1: Depends on OpenSSL package now - added.
2: Can not access root hints in the `/etc/unbound/` folder any more. (moved to `/var/lib/unbound`)

Test results running from this branch/version:

```
❯ dig google.com @127.0.0.1 -p 5053

; <<>> DiG 9.17.22 <<>> google.com @127.0.0.1 -p 5053
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57482
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             314     IN      A       142.251.186.113
google.com.             314     IN      A       142.251.186.102
google.com.             314     IN      A       142.251.186.100
google.com.             314     IN      A       142.251.186.138
google.com.             314     IN      A       142.251.186.101
google.com.             314     IN      A       142.251.186.139

;; Query time: 1 msec
;; SERVER: 127.0.0.1#5053(127.0.0.1) (UDP)
;; WHEN: Fri Jul 04 18:15:25 CDT 2025
;; MSG SIZE  rcvd: 135
```
