### PR TITLE
fix(security): Update Alpine version to address CVE-2025-5994 in unbound

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:20250108
+FROM alpine:3.22.1
 
 # meta
 LABEL \
@@ -10,7 +10,7 @@ LABEL \
 	org.label-schema.schema-version="1.0"
 
 
-RUN apk add --update --no-cache unbound curl openssl ca-certificates s6 
+RUN apk add --no-cache unbound curl openssl ca-certificates s6 
 
 RUN mkdir -p /var/lib/unbound \
  && curl -o /var/lib/unbound/root.hints https://www.internic.net/domain/named.cache \


### PR DESCRIPTION
The update of the base alpine version will allow an install of the latest version of unbound, `1.23.1`, which addresses CVE-2025-5994.
Switching to the latest version should also trigger renovate PRs when updated versions are available.

[Unbound 1.23.1](https://nlnetlabs.nl/projects/unbound/download/#unbound-1-23-1)
[CVE-2025-5994](https://nvd.nist.gov/vuln/detail/CVE-2025-5994)